### PR TITLE
Update tests due to solc 0.4.9 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "homepage": "https://github.com/Arachnid/ens#readme",
   "dependencies": {
     "ethereumjs-testrpc": "^2.2.4",
-    "solc": "^0.4.1"
+    "solc": "^0.4.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ens",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Implementations for registrars and local resolvers for the Ethereum Name Service",
   "scripts": {
     "test": "mocha"

--- a/test/fifsregistrar_test.js
+++ b/test/fifsregistrar_test.js
@@ -21,7 +21,7 @@ describe('FIFSRegistrar', function() {
 
 	before(function() {
 		this.timeout(10000);
-		registrarCode = utils.compileContract(['interface.sol', 'FIFSRegistrar.sol']).contracts['FIFSRegistrar'];
+		registrarCode = utils.compileContract(['interface.sol', 'FIFSRegistrar.sol']).contracts['FIFSRegistrar.sol:FIFSRegistrar'];
 	});
 
 	beforeEach(function(done) {

--- a/test/publicresolver_test.js
+++ b/test/publicresolver_test.js
@@ -21,7 +21,7 @@ describe('PublicResolver', function() {
 
 	before(function() {
 		this.timeout(10000);
-		resolverCode = utils.compileContract(['interface.sol', 'PublicResolver.sol']).contracts['PublicResolver'];
+		resolverCode = utils.compileContract(['interface.sol', 'PublicResolver.sol']).contracts['PublicResolver.sol:PublicResolver'];
 	});
 
 	beforeEach(function(done) {

--- a/test/reverseregistrar_test.js
+++ b/test/reverseregistrar_test.js
@@ -25,7 +25,7 @@ describe('ReverseRegistrar', function() {
 
     before(function() {
         this.timeout(10000);
-        registrarCode = utils.compileContract(['interface.sol', 'ReverseRegistrar.sol']).contracts['ReverseRegistrar'];
+        registrarCode = utils.compileContract(['interface.sol', 'ReverseRegistrar.sol']).contracts['ReverseRegistrar.sol:ReverseRegistrar'];
     });
 
     beforeEach(function(done) {

--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -26,9 +26,9 @@ describe('SimpleHashRegistrar', function() {
 	before(function() {
 		this.timeout(30000);
 		var code = utils.compileContract(['interface.sol', 'HashRegistrarSimplified.sol']);
-		registrarABI = JSON.parse(code.contracts['Registrar'].interface);
-		registrarBytecode = code.contracts['Registrar'].bytecode;
-		deedABI = JSON.parse(code.contracts['Deed'].interface);
+		registrarABI = JSON.parse(code.contracts['HashRegistrarSimplified.sol:Registrar'].interface);
+		registrarBytecode = code.contracts['HashRegistrarSimplified.sol:Registrar'].bytecode;
+		deedABI = JSON.parse(code.contracts['HashRegistrarSimplified.sol:Deed'].interface);
 	});
 
 	beforeEach(function(done) {

--- a/test/testregistrar_test.js
+++ b/test/testregistrar_test.js
@@ -21,7 +21,7 @@ describe('FIFSRegistrar', function() {
 
     before(function() {
         this.timeout(10000);
-        registrarCode = utils.compileContract(['interface.sol', 'TestRegistrar.sol']).contracts['TestRegistrar'];
+        registrarCode = utils.compileContract(['interface.sol', 'TestRegistrar.sol']).contracts['TestRegistrar.sol:TestRegistrar'];
     });
 
     beforeEach(function(done) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -26,7 +26,7 @@ module.exports = {
 	compileContract: compileContract,
 	deployENS: function (account, done) {
 		if(ensCode == null)
-			ensCode = compileContract(['ENS.sol', 'interface.sol']).contracts['ENS'];
+			ensCode = compileContract(['ENS.sol', 'interface.sol']).contracts['ENS.sol:ENS'];
 		return web3.eth.contract(JSON.parse(ensCode.interface)).new(
 		    {
 		    	from: account,


### PR DESCRIPTION
As keys in result from `solc.compile(...)` now are prefixed with respective filenames, tests were failing on me.

For infos on update see:
solc-js 0.4.9 update: https://github.com/ethereum/solc-js/pull/82
Solidity 0.4.9 update: https://github.com/ethereum/solidity/releases/tag/v0.4.9