### PR TITLE
Index sealed bids by sender, to prevent frontrunning

### DIFF
--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -91,7 +91,7 @@ describe('SimpleHashRegistrar', function() {
 				});
 			},
 			function(done) {
-				registrar.sealedBids(bid, function(err, deedAddress) {
+				registrar.sealedBids(accounts[0], bid, function(err, deedAddress) {
 					assert.equal(err, null, err);
 					web3.eth.getBalance(deedAddress, function(err, balance) {
 						assert.equal(err, null, err);


### PR DESCRIPTION
By not keying sealed bids against the sender, we introduce a variety of frontrunning attacks, allowing attackers to invalidate others' bids. This patch fixes this by indexing each bid against the submitter, and making bids only revealable by the account that submitted them. Duplicate sealed bids are allowed as long as they come from different accounts.