### PR TITLE
Adjust fees

### DIFF
--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -328,22 +328,22 @@ contract Registrar {
 
         var auctionState = state(_hash);
         if(auctionState == Mode.Owned) {
-            // Too late! Bidder loses their bid.
-            bid.closeDeed(0);
+            // Too late! Bidder loses their bid. Get's 0.5% back.
+            bid.closeDeed(5);
             BidRevealed(_hash, _owner, actualValue, 1);
         } else if(auctionState != Mode.Reveal) {
             // Invalid phase
             throw;
         } else if (_value < minPrice) {
-            // Bid too low, refund 99.9%
-            bid.closeDeed(999);
+            // Bid too low, refund 99.5%
+            bid.closeDeed(995);
             BidRevealed(_hash, _owner, actualValue, 0);
         } else if (_value > h.highestBid) {
             // new winner
-            // cancel the other bid, refund 99.9%
+            // cancel the other bid, refund 99.5%
             if(address(h.deed) != 0) {
                 Deed previousWinner = h.deed;
-                previousWinner.closeDeed(999);
+                previousWinner.closeDeed(995);
             }
             
             // set new winner
@@ -355,11 +355,11 @@ contract Registrar {
         } else if (_value > h.value) {
             // not winner, but affects second place
             h.value = actualValue;
-            bid.closeDeed(999);
+            bid.closeDeed(995);
             BidRevealed(_hash, _owner, actualValue, 3);
         } else {
             // bid doesn't affect auction
-            bid.closeDeed(999);
+            bid.closeDeed(995);
             BidRevealed(_hash, _owner, actualValue, 4);
         }
     }

--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -108,15 +108,15 @@ describe('SimpleHashRegistrar', function() {
 		this.timeout(5000);
 		var bidData = [
 			// A regular bid
-			{description: 'A regular bid', account: accounts[0], value: 1.1e18, deposit: 2.0e18, salt: 1, expectedFee: 0.001 },
+			{description: 'A regular bid', account: accounts[0], value: 1.1e18, deposit: 2.0e18, salt: 1, expectedFee: 0.005 },
 			// A better bid
 			{description: 'Winning bid', account: accounts[1], value: 2.0e18, deposit: 2.0e18, salt: 2, expectedFee: 0.75 },
 			// Lower, but affects second place
-			{description: 'Losing bid that affects price', account: accounts[2], value: 1.5e18, deposit: 2.0e18, salt: 3, expectedFee: 0.001 },
+			{description: 'Losing bid that affects price', account: accounts[2], value: 1.5e18, deposit: 2.0e18, salt: 3, expectedFee: 0.005 },
 			// No effect
-			{description: 'Losing bid that doesn\'t affect price', account: accounts[3], value: 1.2e18, deposit: 2.0e18, salt: 4, expectedFee: 0.001 },
+			{description: 'Losing bid that doesn\'t affect price', account: accounts[3], value: 1.2e18, deposit: 2.0e18, salt: 4, expectedFee: 0.005 },
 			// Deposit smaller than value
-			{description: 'Bid with deposit less than claimed value', account: accounts[4], value: 1.3e18, deposit: 1.0e17, salt: 5, expectedFee: 0.001 },
+			{description: 'Bid with deposit less than claimed value', account: accounts[4], value: 1.3e18, deposit: 1.0e17, salt: 5, expectedFee: 0.005 },
 			// Invalid - doesn't reveal
 			{description: 'Bid that wasn\'t revealed in time', account: accounts[5], value: 1.4e18, deposit: 2.0e18, salt: 6, expectedFee: 1.0 }
 		];


### PR DESCRIPTION
Adjusts all fees to 0.5%:

* An invalid bid now returns the same or more than cancelling, therefore the bidder has an incentive to do so.
* All bids that affects auctions burn 0.5% off. For high value auctions, bidding when you don't intend to be the winner can actually be bad: a 1000 ether losing bid will burn 5 ether, hopefully making play bidders think twice before attempting to take high value bids