### PR TITLE
Remove unneeded check in the Registrar ctor

### DIFF
--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -180,7 +180,7 @@ contract Registrar {
     function Registrar(address _ens, bytes32 _rootNode, uint _startDate) {
         ens = AbstractENS(_ens);
         rootNode = _rootNode;
-        registryStarted = _startDate > 0 ? _startDate : now;
+        registryStarted = _startDate;
     }
 
     /**


### PR DESCRIPTION
Removing a check for a `uint _startDate` being less than zero which will
always be false.

Other possible checks are if it's more than specific time (say 4 years)
in the past, but they are not necessarily needed.