### PR TITLE
Prohibit bidding during reveal period

### DIFF
--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -163,7 +163,7 @@ contract Registrar {
     }
     
     modifier registryOpen() {
-        if(now < registryStarted  || now > registryStarted + 4 years) throw;
+        if(now < registryStarted  || now > registryStarted + 4 years || ens.owner(rootNode) != address(this)) throw;
         _;
     }
     

--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -468,4 +468,15 @@ contract Registrar {
         entry h = _entries[_hash];
         h.deed.setRegistrar(registrar);
     }
+
+    /**
+     * @dev Returns a deed created by a previous instance of the registrar.
+     * @param deed The address of the deed.
+     */
+    function returnDeed(Deed deed) {
+        // Only return if we own the deed, and it was created before our start date.
+        if(deed.registrar() != address(this) || deed.creationDate() > registryStarted)
+            throw;
+        deed.closeDeed(1000);
+    }
 }

--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -334,8 +334,8 @@ contract Registrar {
         } else if(auctionState != Mode.Reveal) {
             // Invalid phase
             throw;
-        } else if (_value < minPrice) {
-            // Bid too low, refund 99.5%
+        } else if (_value < minPrice || bid.creationDate() > h.registrationDate - revealPeriod) {
+            // Bid too low or too late, refund 99.5%
             bid.closeDeed(995);
             BidRevealed(_hash, _owner, actualValue, 0);
         } else if (_value > h.highestBid) {

--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -737,6 +737,24 @@ describe('SimpleHashRegistrar', function() {
 					});
 				});
 			},
+			// Deploy a new registrar
+			function(done) {
+				newRegistrar = web3.eth.contract(registrarABI).new(
+				    ens.address,
+				    dotEth,
+				    0,
+				    {
+				    	from: accounts[0],
+				     	data: registrarBytecode,
+				     	gas: 4700000
+				   	}, function(err, contract) {
+				   	    assert.equal(err, null, err);
+				   	    if(contract.address != undefined) {
+				   	    	done();
+					   	}
+				   });
+			},
+			function(done) { ens.setSubnodeOwner(0, web3.sha3('eth'), newRegistrar.address, {from: accounts[0]}, done);},
 			// Advance 26 days to the reveal period
 			function(done) { web3.currentProvider.sendAsync({
 				jsonrpc: "2.0",
@@ -756,7 +774,7 @@ describe('SimpleHashRegistrar', function() {
 				"method": "evm_increaseTime",
 				params: [48 * 60 * 60]}, done);
 			},
-			// Finalize the auction and get the deed address
+			// Get the deed address
 			function(done) {
 				registrar.entries(web3.sha3('name'), function(err, result) {
 					assert.equal(err, null, err);
@@ -764,24 +782,6 @@ describe('SimpleHashRegistrar', function() {
 					done();
 				});
 			},
-			// Deploy a new registrar
-			function(done) {
-				newRegistrar = web3.eth.contract(registrarABI).new(
-				    ens.address,
-				    dotEth,
-				    0,
-				    {
-				    	from: accounts[0],
-				     	data: registrarBytecode,
-				     	gas: 4700000
-				   	}, function(err, contract) {
-				   	    assert.equal(err, null, err);
-				   	    if(contract.address != undefined) {
-				   	    	done();
-					   	}
-				   });
-			},
-			function(done) { ens.setSubnodeOwner(0, web3.sha3('eth'), newRegistrar.address, {from: accounts[0]}, done);},
 			// Transfer the deed
 			function(done) {
 				registrar.transferRegistrars(web3.sha3('name'), {from: accounts[0]}, function(err, txid) {

--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -807,4 +807,20 @@ describe('SimpleHashRegistrar', function() {
 			}
 		], done);
 	})
+
+	it("prohibits starting auctions when it's not the registrar", function(done) {
+		var bid = {account: accounts[0], value: 1e18, deposit: 2e18, salt: 1};
+		var deedAddress = null;
+		var newRegistrar = null;
+		async.series([
+			// Start an auction for 'name'
+			function(done) { ens.setSubnodeOwner(0, web3.sha3('eth'), accounts[0], {from: accounts[0]}, done);},
+			function(done) {
+				registrar.startAuction(web3.sha3('name'), {from: accounts[0]}, function(err, txid) {
+					assert.ok(err.toString().indexOf(utils.INVALID_JUMP) != -1, err);
+					done();
+				});
+			},
+		], done);
+	});
 });


### PR DESCRIPTION
This PR fixes the bug that allowed bidding during the reveal period of an auction. It also establishes a route for anyone who placed bids on the buggy registrar to recover their funds using `returnDeed`. Finally, it adds a new safety restriction to prohibit opening auctions if the registrar is not the owner of the node it's supposed to administer.