### PR TITLE
Add cancelBid and releaseDeed tests

### DIFF
--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -436,6 +436,13 @@ describe('SimpleHashRegistrar', function() {
 					done();
 				});
 			},
+			// Save balance
+			function(done) {
+				web3.eth.getBalance(bid.account, function(err, balance){
+					bid.startingBalance = balance.toFixed();
+					done();
+				});
+			},
 			// Attempt to release the deed early
 			function(done) {
 				registrar.releaseDeed(web3.sha3('releasename'), {from: bid.account}, function(err, txid) {
@@ -455,14 +462,27 @@ describe('SimpleHashRegistrar', function() {
 				registrar.releaseDeed(web3.sha3('releasename'), {from: bid.account}, function(err, txid) {
 					assert.equal(err, null, err);
 					console.log("\t Deed released");
-					done();
+					web3.eth.getBalance(bid.account, function(err, balance){
+						assert.ok(balance.toFixed() > bid.startingBalance);
+						console.log("\t Balance before: "+bid.startingBalance+" after: "+balance.toFixed());
+						done();
+					});
 				});
 			},
-			// Release the deed twice
+			// Attempt to release the deed twice
 			function(done) {
 				registrar.releaseDeed(web3.sha3('releasename'), {from: bid.account}, function(err, txid) {
 					assert.notEqual(err, null, err);
 					console.log("\t Could not release deed twice");
+					done();
+				});
+			},
+			// Check the name has the correct state and owner
+			function(done) {
+				registrar.entries(web3.sha3('releasename'), function(err, result) {
+					assert.equal(err, null, err);
+					assert.equal(result[0], 0); // status == Open
+					console.log("\t Name is Open");
 					done();
 				});
 			},

--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -1,3 +1,4 @@
+
 var assert = require('assert');
 var async = require('async');
 
@@ -115,8 +116,8 @@ describe('SimpleHashRegistrar', function() {
 			{description: 'Losing bid that affects price', account: accounts[2], value: 1.5e18, deposit: 2.0e18, salt: 3, expectedFee: 0.005 },
 			// No effect
 			{description: 'Losing bid that doesn\'t affect price', account: accounts[3], value: 1.2e18, deposit: 2.0e18, salt: 4, expectedFee: 0.005 },
-			// Deposit smaller than value
-			{description: 'Bid with deposit less than claimed value', account: accounts[4], value: 1.3e18, deposit: 1.0e17, salt: 5, expectedFee: 0.005 },
+			// Deposit smaller than value - UPDATED: To highest declared value
+			{description: 'Bid with deposit less than claimed value', account: accounts[4], value: 5.3e18, deposit: 1.0e17, salt: 5, expectedFee: 0.005 },
 			// Invalid - doesn't reveal
 			{description: 'Bid that wasn\'t revealed in time', account: accounts[5], value: 1.4e18, deposit: 2.0e18, salt: 6, expectedFee: 0.995 }
 		];
@@ -234,6 +235,237 @@ describe('SimpleHashRegistrar', function() {
 					done();
 				});
 			}
+		], done);
+	});
+	
+	it('cancels bids', function(done) {
+		this.timeout(5000);
+		var bidData = [
+			// A regular bid
+			{description: 'A regular bid 1', account: accounts[0], value: 1.5e18, deposit: 2.0e18, salt: 1, expectedFee: 0.005 },
+			{description: 'A regular bid 2', account: accounts[1], value: 1.1e18, deposit: 2.0e18, salt: 1, expectedFee: 0.005 },
+			{description: 'A regular bid 3', account: accounts[2], value: 1.1e18, deposit: 2.0e18, salt: 1, expectedFee: 0.005 },
+		];
+		async.series([
+			// Start an auction for 'cancelname'
+			function(done) {
+				registrar.startAuction(web3.sha3('cancelname'), {from: accounts[0]}, done);
+			},
+			// Place each of the bids
+			function(done) {
+				async.each(bidData, function(bid, done) {
+					registrar.shaBid(web3.sha3('cancelname'), bid.account, bid.value, bid.salt, function(err, result) {
+						bid.sealedBid = result;
+						assert.equal(err, null, err);
+						registrar.newBid(bid.sealedBid, {from: bid.account, value: bid.deposit}, function(err, txid) {
+							assert.equal(err, null, err);
+							done();
+						});
+					});
+				}, done);
+			},
+			// Attempt to cancel the first bid and fail
+			function(done) {
+				let bid = bidData[0];
+				registrar.shaBid(web3.sha3('cancelname'), bid.account, bid.value, bid.salt, function(err, result) {
+					bid.sealedBid = result;
+					registrar.cancelBid(bid.account, bid.sealedBid, {from: bid.account}, function(err, txid) {
+						assert.notEqual(err, null, err);
+						registrar.sealedBids(bid.account, bid.sealedBid, function(err, result) {
+							assert.equal(err, null, err);
+							assert.notEqual(result, 0);
+							console.log('\t Bid #1 not cancelled');
+							done();
+						});
+					});
+				});
+			},
+			// Advance 26 days to the reveal period
+			function(done) { web3.currentProvider.sendAsync({
+				jsonrpc: "2.0",
+				"method": "evm_increaseTime",
+				params: [26 * 24 * 60 * 60 + 1]}, done);
+			},
+			
+			// Attempt to cancel the second bid and fail
+			function(done) {
+				let bid = bidData[1];
+				registrar.shaBid(web3.sha3('cancelname'), bid.account, bid.value, bid.salt, function(err, result) {
+					bid.sealedBid = result;
+					registrar.cancelBid(bid.account, bid.sealedBid, {from: bid.account}, function(err, txid) {
+						assert.notEqual(err, null, err);
+						registrar.sealedBids(bid.account, bid.sealedBid, function(err, result) {
+							assert.equal(err, null, err);
+							assert.notEqual(result, 0);
+							console.log('\t Bid #2 not cancelled pre-reveal');
+							done();
+						});
+					});
+				});
+			},	
+			// Reveal the second bid
+			function(done) {
+				let bid = bidData[1];
+				registrar.unsealBid(web3.sha3('cancelname'), bid.account, bid.value, bid.salt, {from: bid.account}, function(err, txid) {
+					assert.equal(err, null, err);
+					console.log('\t Bid #2 revealed');
+					done();
+				});
+			},
+			// Attempt to cancel the second bid and fail
+			function(done) {
+				let bid = bidData[1];
+				registrar.shaBid(web3.sha3('cancelname'), bid.account, bid.value, bid.salt, function(err, result) {
+					bid.sealedBid = result;
+					registrar.cancelBid(bid.account, bid.sealedBid, {from: bid.account}, function(err, txid) {
+						assert.notEqual(err, null, err);
+						registrar.sealedBids(bid.account, bid.sealedBid, function(err, result) {
+							assert.equal(err, null, err);
+							assert.equal(result, 0);
+							console.log('\t Bid #2 not cancelled post-reveal. Sealedbid removed');
+							done();
+						});
+					});
+				});
+			},	
+			// Advance another two days to the end of the auction
+			function(done) { web3.currentProvider.sendAsync({
+				jsonrpc: "2.0",
+				"method": "evm_increaseTime",
+				params: [48 * 60 * 60]}, done);
+			},
+			// Finalize the auction and get the deed address
+			function(done) {
+				registrar.finalizeAuction(web3.sha3('cancelname'), {from: accounts[1]}, function(err, txid) {
+					assert.equal(err, null, err);
+					registrar.entries(web3.sha3('cancelname'), function(err, result) {
+						console.log('\t Auction finalized');
+						assert.equal(err, null, err);
+						done();
+					});
+				});
+			},
+			// Attempt to cancel the third bid and fail
+			function(done) {
+				let bid = bidData[2];
+				registrar.shaBid(web3.sha3('cancelname'), bid.account, bid.value, bid.salt, function(err, result) {
+					bid.sealedBid = result;
+					registrar.cancelBid(bid.account, bid.sealedBid, {from: bid.account}, function(err, txid) {
+						assert.equal(err, null, err);
+						console.log('\t Bid #3 not cancelled post-finalize');
+						done();
+					});
+				});
+			},
+			// Advance another four weeks
+			function(done) { web3.currentProvider.sendAsync({
+				jsonrpc: "2.0",
+				"method": "evm_increaseTime",
+				params: [4 * 7 * 24 * 60 * 60]}, done);
+			},
+
+			// Cancel the third bid
+			function(done) {
+				let bid = bidData[2];
+				registrar.shaBid(web3.sha3('cancelname'), bid.account, bid.value, bid.salt, function(err, result) {
+					bid.sealedBid = result;
+					registrar.cancelBid(bid.account, bid.sealedBid, {from: bid.account}, function(err, txid) {
+						assert.notEqual(err, null, err);
+						console.log('\t Bid #3 cancelled');
+						done();
+					});
+				});
+			},
+			// Attempt to cancel again and fail
+			function(done) {
+				let bid = bidData[2];
+				registrar.shaBid(web3.sha3('cancelname'), bid.account, bid.value, bid.salt, function(err, result) {
+					bid.sealedBid = result;
+					registrar.cancelBid(bid.account, bid.sealedBid, {from: bid.account}, function(err, txid) {
+						assert.notEqual(err, null, err);
+						console.log('\t Bid #3 could not cancel a second time');
+						done();
+					});
+				});
+			}
+		], done);
+	});
+
+	it('releases deed after one year', function(done) {
+		this.timeout(5000);
+		var bid = {description: 'A regular bid', account: accounts[0], value: 1.1e18, deposit: 2.0e18, salt: 1, expectedFee: 0.005 };
+		async.series([
+			// Start an auction for 'releasename'
+			function(done) {
+				registrar.startAuction(web3.sha3('releasename'), {from: bid.account}, done);
+			},
+			// Place the bid
+			function(done) {
+				registrar.shaBid(web3.sha3('releasename'), bid.account, bid.value, bid.salt, function(err, result) {
+					bid.sealedBid = result;
+					assert.equal(err, null, err);
+					registrar.newBid(bid.sealedBid, {from: bid.account, value: bid.deposit}, function(err, txid) {
+						assert.equal(err, null, err);
+						done();
+					});
+				});
+			},
+			// Advance 26 days to the reveal period
+			function(done) { web3.currentProvider.sendAsync({
+				jsonrpc: "2.0",
+				"method": "evm_increaseTime",
+				params: [26 * 24 * 60 * 60 + 1]}, done);
+			},
+			// Reveal the bid
+			function(done) {
+				registrar.unsealBid(web3.sha3('releasename'), bid.account, bid.value, bid.salt, {from: bid.account}, function(err, txid) {
+					assert.equal(err, null, err);
+					done();
+				});
+			},
+			// Advance another two days to the end of the auction
+			function(done) { web3.currentProvider.sendAsync({
+				jsonrpc: "2.0",
+				"method": "evm_increaseTime",
+				params: [48 * 60 * 60]}, done);
+			},
+			// Finalize the auction
+			function(done) {
+				registrar.finalizeAuction(web3.sha3('releasename'), {from: bid.account}, function(err, txid) {
+					assert.equal(err, null, err);
+					done();
+				});
+			},
+			// Attempt to release the deed early
+			function(done) {
+				registrar.releaseDeed(web3.sha3('releasename'), {from: bid.account}, function(err, txid) {
+					assert.notEqual(err, null, err);
+					console.log("\t Could not release early");
+					done();
+				});
+			},
+			// Advance one year
+			function(done) { web3.currentProvider.sendAsync({
+				jsonrpc: "2.0",
+				"method": "evm_increaseTime",
+				params: [365 * 24 * 60 * 60]}, done);
+			},
+			// Release the deed
+			function(done) {
+				registrar.releaseDeed(web3.sha3('releasename'), {from: bid.account}, function(err, txid) {
+					assert.equal(err, null, err);
+					console.log("\t Deed released");
+					done();
+				});
+			},
+			// Release the deed twice
+			function(done) {
+				registrar.releaseDeed(web3.sha3('releasename'), {from: bid.account}, function(err, txid) {
+					assert.notEqual(err, null, err);
+					console.log("\t Could not release deed twice");
+					done();
+				});
+			},
 		], done);
 	});
 

--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -116,7 +116,7 @@ describe('SimpleHashRegistrar', function() {
 			{description: 'Losing bid that affects price', account: accounts[2], value: 1.5e18, deposit: 2.0e18, salt: 3, expectedFee: 0.005 },
 			// No effect
 			{description: 'Losing bid that doesn\'t affect price', account: accounts[3], value: 1.2e18, deposit: 2.0e18, salt: 4, expectedFee: 0.005 },
-			// Deposit smaller than value - UPDATED: To highest declared value
+			// Deposit smaller than value
 			{description: 'Bid with deposit less than claimed value', account: accounts[4], value: 5.3e18, deposit: 1.0e17, salt: 5, expectedFee: 0.005 },
 			// Invalid - doesn't reveal
 			{description: 'Bid that wasn\'t revealed in time', account: accounts[5], value: 1.4e18, deposit: 2.0e18, salt: 6, expectedFee: 0.995 }


### PR DESCRIPTION
**Updates the following tests:**

concludes auctions:
- Update "Bid with deposit less than claimed value" to test correctly for https://github.com/ethereum/ens/issues/49

**Adds the following tests:**

cancelBid:
- Attempt to cancel bid directly after bidding
- Attempt to cancel bid during reveal phase
- Attempt to cancel bid post-reveal phase
- Attempt to cancel bid post-finalize (but with not enough time passed)
- Cancel bid after enough time has passed
- Attempt to cancel an already cancelled bid

releaseDeed:
- Release the deed after one year
- Check account balance before and after release
- Check that name is Open after release
- Attempt to release and already released deed