### PR TITLE
Avoid explicit type conversion.

### DIFF
--- a/FIFSRegistrar.sol
+++ b/FIFSRegistrar.sol
@@ -22,8 +22,8 @@ contract FIFSRegistrar {
      * @param ensAddr The address of the ENS registry.
      * @param node The node that this registrar administers.
      */
-    function FIFSRegistrar(address ensAddr, bytes32 node) {
-        ens = AbstractENS(ensAddr);
+    function FIFSRegistrar(AbstractENS ensAddr, bytes32 node) {
+        ens = ensAddr;
         rootNode = node;
     }
 

--- a/HashRegistrar.sol
+++ b/HashRegistrar.sol
@@ -143,8 +143,8 @@ contract Registrar {
         _;
     }
     
-    function Registrar(address _ens, bytes32 _rootNode) {
-        ens = AbstractENS(_ens);
+    function Registrar(AbstractENS _ens, bytes32 _rootNode) {
+        ens = _ens;
         rootNode = _rootNode;
 
         lastSinceNewRegistry = now;

--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -177,8 +177,8 @@ contract Registrar {
      * @param _ens The address of the ENS
      * @param _rootNode The hash of the rootnode.
      */
-    function Registrar(address _ens, bytes32 _rootNode, uint _startDate) {
-        ens = AbstractENS(_ens);
+    function Registrar(AbstractENS _ens, bytes32 _rootNode, uint _startDate) {
+        ens = _ens;
         rootNode = _rootNode;
         registryStarted = _startDate > 0 ? _startDate : now;
     }

--- a/PublicResolver.sol
+++ b/PublicResolver.sol
@@ -20,8 +20,8 @@ contract PublicResolver {
      * Constructor.
      * @param ensAddr The ENS registrar contract.
      */
-    function PublicResolver(address ensAddr) {
-        ens = AbstractENS(ensAddr);
+    function PublicResolver(AbstractENS ensAddr) {
+        ens = ensAddr;
     }
 
     /**

--- a/ReverseRegistrar.sol
+++ b/ReverseRegistrar.sol
@@ -11,8 +11,8 @@ contract ReverseRegistrar {
      * @param ensAddr The address of the ENS registry.
      * @param node The node hash that this registrar governs.
      */
-    function ReverseRegistrar(address ensAddr, bytes32 node) {
-        ens = AbstractENS(ensAddr);
+    function ReverseRegistrar(AbstractENS ensAddr, bytes32 node) {
+        ens = ensAddr;
         rootNode = node;
     }
 

--- a/TestRegistrar.sol
+++ b/TestRegistrar.sol
@@ -18,8 +18,8 @@ contract TestRegistrar {
      * @param ensAddr The address of the ENS registry.
      * @param node The node that this registrar administers.
      */
-    function TestRegistrar(address ensAddr, bytes32 node) {
-        ens = AbstractENS(ensAddr);
+    function TestRegistrar(AbstractENS ensAddr, bytes32 node) {
+        ens = ensAddr;
         rootNode = node;
     }
 


### PR DESCRIPTION
Solidity allows some types in external functions than are not directly supported by the ABI. These include contract types, which are just interpreted as plain addreses as far as the ABI is concerned but proper type checking is done when functions are called via Solidity.