### PR TITLE
Changes to registry interaction to improve upgradeability

### DIFF
--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -391,8 +391,9 @@ contract Registrar {
 
         h.value =  max(h.value, minPrice);
 
-        // Assign the owner in ENS
-        ens.setSubnodeOwner(rootNode, _hash, h.deed.owner());
+        // Assign the owner in ENS, if we're still the registrar
+        if(ens.owner(rootNode) == address(this))
+            ens.setSubnodeOwner(rootNode, _hash, h.deed.owner());
 
         Deed deedContract = h.deed;
         deedContract.setBalance(h.value);
@@ -426,7 +427,8 @@ contract Registrar {
         h.highestBid = 0;
         h.deed = Deed(0);
 
-        ens.setSubnodeOwner(rootNode, _hash, 0);
+        if(ens.owner(rootNode) == address(this))
+            ens.setSubnodeOwner(rootNode, _hash, 0);
         deedContract.closeDeed(1000);
     }  
 
@@ -443,7 +445,10 @@ contract Registrar {
         bytes32 hash = sha3(unhashedName);
         
         entry h = _entries[hash];
-        ens.setSubnodeOwner(rootNode, hash, 0);
+
+        if(ens.owner(rootNode) == address(this))
+            ens.setSubnodeOwner(rootNode, hash, 0);
+
         if(address(h.deed) != 0) {
             // Reward the discoverer with 50% of the deed
             // The previous owner gets 50%

--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -7,8 +7,7 @@ Temporary Hash Registrar
 ========================
 
 This is a simplified version of a hash registrar. It is purporsefully limited:
-names cannot be six letters or shorter, new auctions will stop after 4 years
-and all ether still locked after 8 years will become unreachable.
+names cannot be six letters or shorter, new auctions will stop after 4 years.
 
 The plan is to test the basic features and then move to a new contract in at most
 2 years, when some sort of renewal mechanism will be enabled.
@@ -420,7 +419,6 @@ contract Registrar {
         entry h = _entries[_hash];
         Deed deedContract = h.deed;
         if(now < h.registrationDate + 1 years && ens.owner(rootNode) == address(this)) throw;
-        if(now > registryStarted + 8 years) throw;
 
         HashReleased(_hash, h.value);
         

--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -412,14 +412,15 @@ contract Registrar {
     }
 
     /**
-     * @dev After some time, the owner can release the property and get their ether back
+     * @dev After some time, or if we're no longer the registrar, the owner can release
+     *      the name and get their ether back.
      * @param _hash The node to release
      */
     function releaseDeed(bytes32 _hash) onlyOwner(_hash) {
         entry h = _entries[_hash];
         Deed deedContract = h.deed;
-        if (now < h.registrationDate + 1 years 
-            || now > registryStarted + 8 years) throw;
+        if(now < h.registrationDate + 1 years && ens.owner(rootNode) == address(this)) throw;
+        if(now > registryStarted + 8 years) throw;
 
         HashReleased(_hash, h.value);
         

--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -559,6 +559,24 @@ describe('SimpleHashRegistrar', function() {
 		], done);
 	});
 
+	it("allows releasing a deed even when no longer the registrar", function(done) {
+		var sealedBid = null;
+		registrar.startAuctionAsync(web3.sha3('name'), {from: accounts[0]})
+			.then((done) => registrar.shaBidAsync(web3.sha3('name'), accounts[0], 1e18, 1))
+			.then((result) => {
+				sealedBid = result;
+				return registrar.newBidAsync(result, {from: accounts[0], value: 1e18});
+			})
+			.then((done) => advanceTimeAsync(26 * 24 * 60 * 60 + 1))
+			.then((done) => registrar.unsealBidAsync(web3.sha3('name'), accounts[0], 1e18, 1, {from: accounts[0]}))
+			.then((done) => advanceTimeAsync(2 * 24 * 60 * 60 + 1))
+			.then((done) => registrar.finalizeAuctionAsync(web3.sha3('name'), {from: accounts[0]}))
+			.then((done) => advanceTimeAsync(365 * 24 * 60 * 60 + 1))
+			.then((done) => ens.setSubnodeOwnerAsync(0, web3.sha3('eth'), accounts[0], {from: accounts[0]}))
+			.then((done) => registrar.releaseDeedAsync(web3.sha3('name'), {from: accounts[0]}))
+			.asCallback(done);
+	});
+
 	it('rejects bids less than the minimum', function(done) {
 		registrar.startAuctionAsync(web3.sha3('name'), {from: accounts[0]})
 			.then((done) => registrar.shaBidAsync(web3.sha3('name'), accounts[0], 1e15 - 1, 1))
@@ -596,6 +614,22 @@ describe('SimpleHashRegistrar', function() {
 			.asCallback(done);
 	});
 
+	it("allows finalizing an auction even when no longer the registrar", function(done) {
+		var sealedBid = null;
+		registrar.startAuctionAsync(web3.sha3('name'), {from: accounts[0]})
+			.then((done) => registrar.shaBidAsync(web3.sha3('name'), accounts[0], 1e18, 1))
+			.then((result) => {
+				sealedBid = result;
+				return registrar.newBidAsync(result, {from: accounts[0], value: 1e18});
+			})
+			.then((done) => advanceTimeAsync(26 * 24 * 60 * 60 + 1))
+			.then((done) => registrar.unsealBidAsync(web3.sha3('name'), accounts[0], 1e18, 1, {from: accounts[0]}))
+			.then((done) => advanceTimeAsync(2 * 24 * 60 * 60 + 1))
+			.then((done) => ens.setSubnodeOwnerAsync(0, web3.sha3('eth'), accounts[0], {from: accounts[0]}))
+			.then((done) => registrar.finalizeAuctionAsync(web3.sha3('name'), {from: accounts[0]}))
+			.asCallback(done);		
+	})
+
 	it("doesn't allow revealing a bid on a name not up for auction", function(done) {
 		var sealedBid = null;
 		registrar.shaBidAsync(web3.sha3('name'), accounts[0], 1e18, 1)
@@ -616,9 +650,6 @@ describe('SimpleHashRegistrar', function() {
 	it("doesn't invalidate long names", function(done) {
 		var sealedBid = null;
 		registrar.startAuctionAsync(web3.sha3('longname'), {from: accounts[0]})
-			.then((done) => registrar.finalizeAuctionAsync(web3.sha3('longname'), {from: accounts[0]}))
-			.then((done) => assert.fail("Expected exception"), (err) => assert.ok(err.toString().indexOf(utils.INVALID_JUMP) != -1, err))
-
 			.then((done) => registrar.shaBidAsync(web3.sha3('longname'), accounts[0], 1e18, 1))
 			.then((result) => {
 				sealedBid = result;
@@ -630,6 +661,23 @@ describe('SimpleHashRegistrar', function() {
 			.then((done) => registrar.finalizeAuctionAsync(web3.sha3('longname'), {from: accounts[0]}))
 			.then((done) => registrar.invalidateNameAsync('longname', {from: accounts[0]}))
 			.then((done) => assert.fail("Expected exception"), (err) => assert.ok(err.toString().indexOf(utils.INVALID_JUMP) != -1, err))
+			.asCallback(done);
+	});
+
+	it("allows invalidation even when no longer the registrar", function(done) {
+		var sealedBid = null;
+		registrar.startAuctionAsync(web3.sha3('name'), {from: accounts[0]})
+			.then((done) => registrar.shaBidAsync(web3.sha3('name'), accounts[0], 1e18, 1))
+			.then((result) => {
+				sealedBid = result;
+				return registrar.newBidAsync(result, {from: accounts[0], value: 1e18});
+			})
+			.then((done) => advanceTimeAsync(26 * 24 * 60 * 60 + 1))
+			.then((done) => registrar.unsealBidAsync(web3.sha3('name'), accounts[0], 1e18, 1, {from: accounts[0]}))
+			.then((done) => advanceTimeAsync(2 * 24 * 60 * 60 + 1))
+			.then((done) => registrar.finalizeAuctionAsync(web3.sha3('name'), {from: accounts[0]}))
+			.then((done) => ens.setSubnodeOwnerAsync(0, web3.sha3('eth'), accounts[0], {from: accounts[0]}))
+			.then((done) => registrar.invalidateNameAsync('name', {from: accounts[0]}))
 			.asCallback(done);
 	});
 

--- a/test/simplehashregistrar_test.js
+++ b/test/simplehashregistrar_test.js
@@ -559,7 +559,7 @@ describe('SimpleHashRegistrar', function() {
 		], done);
 	});
 
-	it("allows releasing a deed even when no longer the registrar", function(done) {
+	it("allows releasing a deed immediately when no longer the registrar", function(done) {
 		var sealedBid = null;
 		registrar.startAuctionAsync(web3.sha3('name'), {from: accounts[0]})
 			.then((done) => registrar.shaBidAsync(web3.sha3('name'), accounts[0], 1e18, 1))
@@ -571,7 +571,6 @@ describe('SimpleHashRegistrar', function() {
 			.then((done) => registrar.unsealBidAsync(web3.sha3('name'), accounts[0], 1e18, 1, {from: accounts[0]}))
 			.then((done) => advanceTimeAsync(2 * 24 * 60 * 60 + 1))
 			.then((done) => registrar.finalizeAuctionAsync(web3.sha3('name'), {from: accounts[0]}))
-			.then((done) => advanceTimeAsync(365 * 24 * 60 * 60 + 1))
 			.then((done) => ens.setSubnodeOwnerAsync(0, web3.sha3('eth'), accounts[0], {from: accounts[0]}))
 			.then((done) => registrar.releaseDeedAsync(web3.sha3('name'), {from: accounts[0]}))
 			.asCallback(done);

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var async = require('async');
 var fs = require('fs');
+var Promise = require('bluebird');
 var solc = require('solc');
 var TestRPC = require('ethereumjs-testrpc');
 var Web3 = require('web3');
@@ -27,7 +28,7 @@ module.exports = {
 	deployENS: function (account, done) {
 		if(ensCode == null)
 			ensCode = compileContract(['ENS.sol', 'interface.sol']).contracts['ENS.sol:ENS'];
-		return web3.eth.contract(JSON.parse(ensCode.interface)).new(
+		var ens = web3.eth.contract(JSON.parse(ensCode.interface)).new(
 		    {
 		    	from: account,
 		     	data: ensCode.bytecode,
@@ -35,9 +36,11 @@ module.exports = {
 		   	}, function(err, contract) {
 		   	    assert.equal(err, null, err);
 		   	    if(contract.address != undefined) {
+		   	    	ens = Promise.promisifyAll(ens);
 		   	    	done();
 			   	}
 		   });
+		return ens;
 	},
 	deployENSLLL: function(account, done) {
 		if(ensLLLCode == null) {


### PR DESCRIPTION
`finalizeAuction`, `releaseDeed`, and `invalidateName` all now work when the contract is the current registrar, by first checking this and skipping ENS changes if it's not. This means that these operations continue to function after the contract is replaced by a newer one, allowing in-progress auctions to complete normally.

This change means that the registrar can be replaced by a new one that need only care about transitioning completed auctions from the previous registrar. An upgrade process would go like this:
 1. Write a new registrar with an additional check in startAuction that prohibits starting any auction whose state in the old registrar is anything other than 'open'. Add a function to the new registrar that permits migrating a deed for a completed auction from the old registrar to the new one.
 2. Deploy the new registrar and set it as the active registrar in ENS.
 3. Anyone with an active auction on the old registrar at deployment time should complete the auction on the old registrar, then use the migration process to move the name to the new registrar in order to register it in ENS.
 4. New auctions should be started on the new registrar - the old one will not permit creation of any new auctions.

This means that the new registrar need only implement a restriction on starting auctions, and a migration process for completed auctions; it does not need to deal with auctions in progress at the time of deployment.

In addition, we allow users to release a name and recover their deposit as soon as the registrar is no longer current, rather than requiring them to wait a year if they don't want to upgrade.