### PR TITLE
Use Alpine instead of Ubuntu

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,5 @@
-FROM ubuntu:latest
-RUN (apt-get update \
-     && apt-get -y install git lsb-release sudo software-properties-common)
+FROM alpine:latest
+RUN apk add --no-cache git
 RUN (git clone --recursive https://github.com/ethereum/solidity.git \
      && cd solidity \
      && git checkout 4633f3de \

--- a/build/README.md
+++ b/build/README.md
@@ -4,7 +4,7 @@ This directory contains a dockerfile that allows you to reproduce the binary of 
 To use it, first examine the Dockerfile to verify it's doing what you think it is. Then, from the main directory run:
 
     docker build --tag=lllc build
-    docker run -v $PWD:/ens a810a0a09f2b -x /ens/ENS.lll > ENS.lll.bin
+    docker run -v $PWD:/ens lllc:latest -x /ens/ENS.lll > ENS.lll.bin
     git diff
 
 If the last command shows no differences, you can be sure that the bin file represents the accurate output of the specified version of lllc.


### PR DESCRIPTION
Saves about ~500MB storage and 182MB in network download if you don't have the `ubuntu:latest` image already. It costs you 5MB in network traffic if you already do.
https://www.brianchristner.io/docker-image-base-os-size-comparison/