### PR TITLE
Wrap in describe the allowed and forbidden tests on transferring ownership

### DIFF
--- a/test/fifsregistrar_test.js
+++ b/test/fifsregistrar_test.js
@@ -18,33 +18,34 @@ describe('FIFSRegistrar', function() {
 	var registrar = null;
 	var ens = null;
 
-
 	before(function() {
 		this.timeout(10000);
 		registrarCode = utils.compileContract(['interface.sol', 'FIFSRegistrar.sol']).contracts['FIFSRegistrar.sol:FIFSRegistrar'];
 	});
 
 	beforeEach(function(done) {
+		this.timeout(4000);
 		async.series([
 			function(done) { ens = utils.deployENS(accounts[0], done); },
 			function(done) {
 				registrar = web3.eth.contract(JSON.parse(registrarCode.interface)).new(
-				    ens.address,
-				    0,
-				    {
-				    	from: accounts[0],
-				     	data: registrarCode.bytecode,
-				     	gas: 4700000
-				   	}, function(err, contract) {
-				   		if(contract.address != undefined)
-				   	    	ens.setOwner(0, registrar.address, {from: accounts[0]}, done);
-				   	});
+					ens.address,
+					0,
+					{
+						from: accounts[0],
+						data: registrarCode.bytecode,
+						gas: 4700000
+					}, function(err, contract) {
+						if(contract.address != undefined)
+							ens.setOwner(0, registrar.address, {from: accounts[0]}, done);
+					});
 			}],
 			done
 		);
 	});
 
 	it('registers names', function(done) {
+		this.slow(300);
 		async.series([
 			function(done) {
 				registrar.register(web3.sha3('eth'), accounts[0], {from: accounts[0]}, done);
@@ -67,37 +68,51 @@ describe('FIFSRegistrar', function() {
 		);
 	});
 
-	it('transfers names', function(done) {
-		async.series([
-			function(done) {
-				registrar.register(web3.sha3('eth'), accounts[0], {from: accounts[0]}, done);
-			},
-			function(done) {
-				registrar.register(web3.sha3('eth'), accounts[1], {from: accounts[0]}, done);
-			},
-			function(done) {
-				ens.owner(utils.node, function(err, address) {
-					assert.equal(err, null, err);
-					assert.equal(address, accounts[1]);
-					done();
-				});
-			}],
-			done
-		);		
-	});
+	describe("transferring names", function() {
+		
+		beforeEach("register an unclaimed name", function(done) {
+			async.series([
+				function(done) {
+					registrar.register(web3.sha3('eth'), accounts[0], {from: accounts[0]}, done);
+				},
+				function(done) {
+					ens.owner(utils.node, function(err, address) {
+						assert.equal(err, null, err);
+						assert.equal(address, accounts[0]);
+						done();
+					});
+				}],
+				done
+			);
+		});
 
-	it('forbids transferring names you do not own', function(done) {
-		async.series([
-			function(done) {
-				registrar.register(web3.sha3('eth'), accounts[1], {from: accounts[0]}, done);
-			},
-			function(done) {
-				registrar.register(web3.sha3('eth'), accounts[0], {from: accounts[0]}, function(err, txid) {
-					assert.ok(err.toString().indexOf(utils.INVALID_JUMP) != -1, err);
-					done();
-				});
-			}],
-			done
-		);
+		it("transfers the name you own", function(done) {
+			this.slow(200);
+			async.series([
+				function(done) {
+					registrar.register(web3.sha3('eth'), accounts[1], {from: accounts[0]}, done);
+				},
+				function(done) {
+					ens.owner(utils.node, function(err, address) {
+						assert.equal(err, null, err);
+						assert.equal(address, accounts[1]);
+						done();
+					});
+				}],
+				done
+			);		
+		});
+
+		it('forbids transferring the name you do not own', function(done) {
+			async.series([
+				function(done) {
+					registrar.register(web3.sha3('eth'), accounts[1], {from: accounts[1]}, function(err, txid) {
+						assert.ok(err.toString().indexOf(utils.INVALID_JUMP) != -1, err);
+						done();
+					});
+				}],
+				done
+			);
+		});
 	});
 });


### PR DESCRIPTION
I was thinking that it would be neater to wrap the passing and failing tests in their own `describe`. By showing them together, and differing by a single account, it puts forward the difference that makes it pass or fail.
Is that the kind of change you welcome?