### PR TITLE
forbid high value names

### DIFF
--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -388,14 +388,21 @@ contract Registrar {
         entry h = _entries[_hash];
 
         h.value =  max(h.value, minPrice);
+        h.deed.setBalance(h.value, true);
 
-        // Assign the owner in ENS, if we're still the registrar
-        if(ens.owner(rootNode) == address(this))
-            ens.setSubnodeOwner(rootNode, _hash, h.deed.owner());
+        if (h.value >= 1000 ether) {
+            // Temporary registrar will not accept high value names yet
+            h.deed.closeDeed(995);
+            h.deed = Deed(0);
+            HashInvalidated(hash, unhashedName, h.value, h.registrationDate);
 
-        Deed deedContract = h.deed;
-        deedContract.setBalance(h.value, true);
-        HashRegistered(_hash, deedContract.owner(), h.value, h.registrationDate);
+        } else {
+            // Assign the owner in ENS, if we're still the registrar
+            if(ens.owner(rootNode) == address(this))
+                ens.setSubnodeOwner(rootNode, _hash, h.deed.owner());
+
+            HashRegistered(_hash, h.deed.owner(), h.value, h.registrationDate);
+        }
     }
 
     /**


### PR DESCRIPTION
(In progress, haven't added tests yet: this is controversial and might not get support from the community)

This would prevent any names being registered for higher than 1000 ether on the permanent registrar. It means that if two bids higher than 1000 are placed on any name (by the same bidder or not) then the name cannot be registered by anyone. The purpose is to have a softer launch of ENS, and not allow high value names until the next update (which could even be a minor update that would remove only that particular feature)