### PR TITLE
slowly lower the min length

### DIFF
--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -140,7 +140,7 @@ contract Registrar {
         } else {
             if(entry.highestBid == 0) {
                 return Mode.Open;
-            } else if(entry.deed == Deed(0)) {
+            } else if(minLength(now) == 6 && entry.deed == Deed(0)) {
                 return Mode.Forbidden;
             } else {
                 return Mode.Owned;
@@ -444,6 +444,15 @@ contract Registrar {
     }  
 
     /**
+     * @dev Minimum length starts at 12 weeks reducing 1 letter every 4 weeks until min of 6
+     * @param timestamp The time for which you want to know the date.
+     */
+
+    function minLength(uint timestamp) constant returns (uint minLength) {
+        return uint minLength = max(6, 12 - (timestamp - registryStarted)/(4 weeks));
+    }
+
+    /**
      * @dev Submit a name 6 characters long or less. If it has been registered, 
      * the submitter will earn 50% of the deed value. We are purposefully
      * handicapping the simplified registrar as a way to force it into being restructured
@@ -452,8 +461,7 @@ contract Registrar {
      * 
      */
     function invalidateName(string unhashedName) inState(sha3(unhashedName), Mode.Owned) {
-        uint minLength = max(6, 12 - (now - registryStarted)/(4 weeks));
-        if (strlen(unhashedName) > minLength ) throw;
+        if (strlen(unhashedName) > minLength(now) ) throw;
         bytes32 hash = sha3(unhashedName);
         
         entry h = _entries[hash];

--- a/HashRegistrarSimplified.sol
+++ b/HashRegistrarSimplified.sol
@@ -104,7 +104,7 @@ contract Registrar {
     enum Mode { Open, Auction, Owned, Forbidden, Reveal }
     uint32 constant auctionLength = 5 days;
     uint32 constant revealPeriod = 48 hours;
-    uint32 constant initialAuctionPeriod = 4 weeks;
+    uint32 constant initialAuctionPeriod = 2 weeks;
     uint constant minPrice = 0.01 ether;
     uint public registryStarted;
 
@@ -452,7 +452,8 @@ contract Registrar {
      * 
      */
     function invalidateName(string unhashedName) inState(sha3(unhashedName), Mode.Owned) {
-        if (strlen(unhashedName) > 6 ) throw;
+        uint minLength = max(6, 12 - (now - registryStarted)/(4 weeks));
+        if (strlen(unhashedName) > minLength ) throw;
         bytes32 hash = sha3(unhashedName);
         
         entry h = _entries[hash];


### PR DESCRIPTION
Classify this as another attempt of trying to make the launch softer and slower without severely crippling the ENS functionality:

* Lower the initial auction period to 2 weeks
* Make it so that the initial name length starts at 12
* Every month, automatically reduce that limit one letter, arriving at the current state of 7 letters or more after 6 months