### PR TITLE
Explain indirect selfdestruct

### DIFF
--- a/contracts/HashRegistrarSimplified.sol
+++ b/contracts/HashRegistrarSimplified.sol
@@ -86,6 +86,10 @@ contract Deed {
      */
     function destroyDeed() {
         if (active) throw;
+        
+        // Instead of selfdestruct(owner), invoke owner fallback function to allow
+        // owner to log an event if desired; but owner should also be aware that
+        // its fallback function can also be invoked by setBalance
         if(owner.send(this.balance)) {
             selfdestruct(burn);
         }


### PR DESCRIPTION
Explanation of why the code is not simply `selfdestruct(owner)` https://github.com/ethereum/ens/issues/124