### PR TITLE
Use pygments-lexer-solidity package for Solidity syntax highlighting

### DIFF
--- a/docs/implementers.rst
+++ b/docs/implementers.rst
@@ -9,7 +9,7 @@ Writing a resolver
 
 Resolvers are specified in EIP137_. A resolver must implement the following method:
 
-::
+.. code-block:: solidity
 
     function supportsInterface(bytes4 interfaceID) constant returns (bool)
 
@@ -33,7 +33,7 @@ Additionally, the `content()` interface is currently used as a defacto standard 
 
 For example, a simple resolver that supports only the `addr` type might look something like this:
 
-::
+.. code-block:: solidity
 
     contract SimpleResolver {
         function supportsInterface(bytes4 interfaceID) constant returns (bool) {
@@ -52,7 +52,7 @@ Resolving names onchain
 
 Solidity libraries for onchain resolution are not yet available, but ENS resolution is straightforward enough it can be done trivially without a library. Contracts may use the following interfaces:
 
-::
+.. code-block:: solidity
 
     contract ENS {
         function owner(bytes32 node) constant returns (address);
@@ -72,7 +72,7 @@ For resolution, only the `resolver()` function in the ENS contract is required; 
 
 With these definitions, looking up a name given its node hash is straightforward:
 
-::
+.. code-block:: solidity
 
     contract MyContract {
         ENS ens;
@@ -94,7 +94,7 @@ Writing a registrar
 
 A registrar in ENS is simply any contract that owns a name, and allocates subdomains of it according to some set of rules defined in the contract code. A trivial first in first served contract is demonstrated below, using the ENS interface definition defined earlier.
 
-::
+.. code-block:: solidity
 
     contract FIFSRegistrar {
         ENS ens;

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx_rtd_theme
+pygments-lexer-solidity


### PR DESCRIPTION
### Issue

The [Implementers](http://docs.ens.domains/en/latest/implementers.html) page has Solidity code, but no syntax highlighting for that.

### Solution

Add the [pygments-lexer-solidity PyPI package](https://pypi.python.org/pypi/pygments-lexer-solidity) (and a `requirements.txt` at that), and use that.

### Requires changes to ReadTheDocs project!

As described in their [FAQ answer](https://docs.readthedocs.io/en/latest/faq.html#my-project-isn-t-building-with-autodoc).

On the [Advanced project settings](https://readthedocs.org/dashboard/ens/advanced/) page:

* tick "Install your project inside a virtualenv";
* set "requirements file" to `docs/requirements.txt`;
* (recommended) further down, tick "Give the virtual environment access to the global site-packages dir".

The latter will re-use system-wide Sphinx and theme, instead of installing them separately in the virtualenv, speeding up the build a bit.

**There will be 1 failed build on RTD:**

* If the PR is merged first, then RTD won't understand the `solidity` code block.
* If the RTD project changes are made first, then `doc/requirements.txt` won't be available.

### Notes

* `pygments-lexer-solidity` sources: https://gitlab.com/veox/pygments-lexer-solidity
* Comparison: [before](http://docs.ens.domains/en/latest/implementers.html#writing-a-registrar) and [after](https://veox-ens.readthedocs.io/en/use-pygments-solidity-lexer/implementers.html#writing-a-registrar).