### PR TITLE
[Document]Fix highest bid value access index

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -148,7 +148,7 @@ and the value of the current winning bid with
 
 ::
 
-    web3.fromWei(ethRegistrar.entries(web3.sha3('name'))[3], 'ether');
+    web3.fromWei(ethRegistrar.entries(web3.sha3('name'))[4], 'ether');
 
 Finalizing the auction
 ----------------------


### PR DESCRIPTION
It has been changed to 4

```
function entries(bytes32 _hash) constant returns (Mode, address, uint, uint, uint) {
        entry h = _entries[_hash];
        return (state(_hash), h.deed, h.registrationDate, h.value, h.highestBid);
    }
```