### PR TITLE
Rewrite reverse registrar for better usability

### DIFF
--- a/contracts/ReverseRegistrar.sol
+++ b/contracts/ReverseRegistrar.sol
@@ -1,21 +1,78 @@
-pragma solidity ^0.4.0;
+pragma solidity ^0.4.10;
 
-import './AbstractENS.sol';
+import "./AbstractENS.sol";
+
+contract Resolver {
+    function setName(bytes32 node, string name) public;
+}
+
+/**
+ * @dev Provides a default implementation of a resolver for reverse records,
+ * which permits only the owner to update it.
+ */
+contract DefaultReverseResolver is Resolver {
+    // namehash('addr.reverse')
+    bytes32 constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
+
+    AbstractENS public ens;
+    mapping(bytes32=>string) public name;
+    
+    /**
+     * @dev Constructor
+     * @param ensAddr The address of the ENS registry.
+     */
+    function DefaultReverseResolver(AbstractENS ensAddr) {
+        ens = ensAddr;
+
+        // Assign ownership of the reverse record to our deployer
+        var registrar = ReverseRegistrar(ens.owner(ADDR_REVERSE_NODE));
+        if(address(registrar) != 0) {
+            registrar.claim(msg.sender);
+        }
+    }
+
+    /**
+     * @dev Only permits calls by the reverse registrar.
+     * @param node The node permission is required for.
+     */
+    modifier owner_only(bytes32 node) {
+        require(msg.sender == ens.owner(node));
+        _;
+    }
+
+    /**
+     * @dev Sets the name for a node.
+     * @param node The node to update.
+     * @param _name The name to set.
+     */
+    function setName(bytes32 node, string _name) public owner_only(node) {
+        name[node] = _name;
+    }
+}
 
 contract ReverseRegistrar {
+    // namehash('addr.reverse')
+    bytes32 constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
+
     AbstractENS public ens;
-    bytes32 public rootNode;
+    Resolver public defaultResolver;
 
     /**
      * @dev Constructor
      * @param ensAddr The address of the ENS registry.
-     * @param node The node hash that this registrar governs.
+     * @param resolverAddr The address of the default reverse resolver.
      */
-    function ReverseRegistrar(AbstractENS ensAddr, bytes32 node) {
+    function ReverseRegistrar(AbstractENS ensAddr, Resolver resolverAddr) {
         ens = ensAddr;
-        rootNode = node;
-    }
+        defaultResolver = resolverAddr;
 
+        // Assign ownership of the reverse record to our deployer
+        var oldRegistrar = ReverseRegistrar(ens.owner(ADDR_REVERSE_NODE));
+        if(address(oldRegistrar) != 0) {
+            oldRegistrar.claim(msg.sender);
+        }
+    }
+    
     /**
      * @dev Transfers ownership of the reverse ENS record associated with the
      *      calling account.
@@ -23,9 +80,50 @@ contract ReverseRegistrar {
      * @return The ENS node hash of the reverse record.
      */
     function claim(address owner) returns (bytes32 node) {
+        return claimWithResolver(owner, 0);
+    }
+
+    /**
+     * @dev Transfers ownership of the reverse ENS record associated with the
+     *      calling account.
+     * @param owner The address to set as the owner of the reverse record in ENS.
+     * @param resolver The address of the resolver to set; 0 to leave unchanged.
+     * @return The ENS node hash of the reverse record.
+     */
+    function claimWithResolver(address owner, address resolver) returns (bytes32 node) {
         var label = sha3HexAddress(msg.sender);
-        ens.setSubnodeOwner(rootNode, label, owner);
-        return sha3(rootNode, label);
+        node = sha3(ADDR_REVERSE_NODE, label);
+        var currentOwner = ens.owner(node);
+
+        // Update the resolver if required
+        if(resolver != 0 && resolver != ens.resolver(node)) {
+            // Transfer the name to us first if it's not already
+            if(currentOwner != address(this)) {
+                ens.setSubnodeOwner(ADDR_REVERSE_NODE, label, this);
+                currentOwner = address(this);
+            }
+            ens.setResolver(node, resolver);
+        }
+
+        // Update the owner if required
+        if(currentOwner != owner) {
+            ens.setSubnodeOwner(ADDR_REVERSE_NODE, label, owner);
+        }
+
+        return node;
+    }
+
+    /**
+     * @dev Sets the `name()` record for the reverse ENS record associated with
+     * the calling account. First updates the resolver to the default reverse
+     * resolver if necessary.
+     * @param name The name to set for this address.
+     * @return The ENS node hash of the reverse record.
+     */
+    function setName(string name) returns (bytes32 node) {
+        node = claimWithResolver(this, defaultResolver);
+        defaultResolver.setName(node, name);
+        return node;
     }
 
     /**
@@ -34,7 +132,7 @@ contract ReverseRegistrar {
      * @return The ENS node hash.
      */
     function node(address addr) constant returns (bytes32 ret) {
-        return sha3(rootNode, sha3HexAddress(addr));
+        return sha3(ADDR_REVERSE_NODE, sha3HexAddress(addr));
     }
 
     /**

--- a/test/reverseregistrar_test.js
+++ b/test/reverseregistrar_test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var async = require('async');
+var namehash = require('eth-ens-namehash');
 var Promise = require('bluebird');
 
 var utils = require('./utils.js');
@@ -14,32 +15,57 @@ before(function() {
     return web3.eth.getAccountsAsync()
         .then(function(acct) {
             accounts = acct
-            node = web3.sha3('0000000000000000000000000000000000000000000000000000000000000000'
-                             + web3.sha3(accounts[0].slice(2).toLowerCase()).slice(2),
-                             {encoding: 'hex'});
+            node = namehash(accounts[0].slice(2).toLowerCase() + ".addr.reverse");
         });
 });
 
+function assertIsContractError(err) {
+    return assert.ok(err.toString().indexOf("invalid JUMP") != -1 || err.toString().indexOf("invalid opcode") != -1, err);
+}
+
 describe('ReverseRegistrar', function() {
+    var resolverCode = null;
     var registrarCode = null;
     var registrar = null;
+    var resolver = null;
     var ens = null;
 
 
     before(function() {
         this.timeout(10000);
-        registrarCode = utils.compileContract(['AbstractENS.sol', 'ReverseRegistrar.sol']).contracts['ReverseRegistrar.sol:ReverseRegistrar'];
+        var compiled = utils.compileContract(['AbstractENS.sol', 'ReverseRegistrar.sol'])
+        resolverCode = compiled.contracts['ReverseRegistrar.sol:DefaultReverseResolver'];
+        registrarCode = compiled.contracts['ReverseRegistrar.sol:ReverseRegistrar'];
     });
 
     beforeEach(function() {
         this.timeout(4000);
         return utils.deployENSAsync(accounts[0])
             .then(function(_ens) {
-                ens = _ens;
+                ens = Promise.promisifyAll(_ens);
+                return new Promise(function(resolve, reject) {
+                    web3.eth.contract(JSON.parse(resolverCode.interface)).new(
+                        ens.address,
+                        {
+                            from: accounts[0],
+                            data: resolverCode.bytecode,
+                            gas: 4700000
+                        },
+                        function(err, contract) {
+                            if (err) {
+                                reject(err);
+                            } else if (typeof contract.address !== "undefined") {
+                                resolver = Promise.promisifyAll(contract);
+                                resolve(resolver);
+                            }
+                        });
+                });
+            })
+            .then(function(resolver) {
                 return new Promise(function(resolve, reject) {
                     web3.eth.contract(JSON.parse(registrarCode.interface)).new(
                         ens.address,
-                        0,
+                        resolver.address,
                         {
                             from: accounts[0],
                             data: registrarCode.bytecode,
@@ -49,17 +75,14 @@ describe('ReverseRegistrar', function() {
                             if (err) {
                                 reject(err);
                             } else if (typeof contract.address !== "undefined") {
-                                resolve(contract);
-                            } else {
-                                // There is to hope that reject or resolve is called
+                                registrar = Promise.promisifyAll(contract);
+                                resolve(registrar);
                             }
                         });
                 });
             })
-            .then(contract => {
-                registrar = Promise.promisifyAll(contract);
-                return ens.setOwnerAsync(0, registrar.address, {from: accounts[0]});
-            });
+            .then(registrar => ens.setSubnodeOwnerAsync(0, web3.sha3('reverse'), accounts[0], {from: accounts[0]}))
+            .then(result => ens.setSubnodeOwnerAsync(namehash('reverse'), web3.sha3('addr'), registrar.address, {from: accounts[0]}));
     });
 
     it('calculates node hashes correctly', function() {
@@ -73,5 +96,48 @@ describe('ReverseRegistrar', function() {
         return registrar.claimAsync(accounts[1], {from: accounts[0]})
             .then(txHash => ens.ownerAsync(node))
             .then(result => assert.equal(result, accounts[1]));
+    });
+
+    it('allows an account to specify resolver', function() {
+        this.slow(150);
+        return registrar.claimWithResolverAsync(accounts[1], accounts[2], {from: accounts[0]})
+            .then(txHash => ens.ownerAsync(node))
+            .then(result => assert.equal(result, accounts[1]))
+            .then(result => ens.resolverAsync(node))
+            .then(result => assert.equal(result, accounts[2]));
+    });
+
+    it('does not overwrite resolver if not specified', function() {
+        this.slow(150);
+        return registrar.claimWithResolverAsync(accounts[1], accounts[2], {from: accounts[0]})
+            .then(txHash => registrar.claimAsync(accounts[3], {from: accounts[0]}))
+            .then(txHash => ens.ownerAsync(node))
+            .then(result => assert.equal(result, accounts[3]))
+            .then(result => ens.resolverAsync(node))
+            .then(result => assert.equal(result, accounts[2]));
+    })
+
+    it('sets name records', function() {
+        this.slow(300);
+        return registrar.setNameAsync('testname', {from: accounts[0], gas: 1000000})
+            .then(hash => ens.resolverAsync(node))
+            .then(resolverAddr => assert.equal(resolverAddr, resolver.address))
+            .then(result => resolver.nameAsync(node))
+            .then(name => assert.equal(name, 'testname'));
+    });
+
+    it('allows the owner to update the name', function() {
+        this.slow(150);
+        return registrar.claimWithResolverAsync(accounts[1], resolver.address, {from: accounts[0]})
+            .then(hash => resolver.setNameAsync(node, 'testname', {from: accounts[1]}))
+            .then(hash => resolver.nameAsync(node))
+            .then(result => assert.equal(result, 'testname'));
+    });
+
+    it('does not allow non-owners to update the name', function() {
+        this.slow(150);
+        return registrar.claimWithResolverAsync(accounts[1], resolver.address, {from: accounts[0]})
+            .then(hash => resolver.setNameAsync(node, 'testname', {from: accounts[0]}))
+            .then((done) => assert.fail("Expected exception"), assertIsContractError);
     });
 });


### PR DESCRIPTION
This PR is a rewrite of the reverse registrar.

Previously, the registrar would allow you to 'claim' a reverse record, assigning ownership to you. The usual flow for a user was this:

 1. Call `ReverseRegistrar.claim()`
 2. Call `ENS.setResolver()` to set a resolver
 3. Call `Resolver.setName()` to set the reverse name

This requires 3 transactions in the common case.

This PR adds new functionality to the reverse resolver, defining a simple default reverse registrar, and adding two new functions:

 - `claimWithResolver`, which assigns ownership of the reverse node after first setting a resolver record.
 - `setName`, which sets the resolver of the reverse node to the default reverse resolver, then updates the name record on it.

Thus, users wanting to set a custom resolver now only need two transactions instead of 3, and users just wanting to set a reverse name now need only a single transaction.