### PR TITLE
changed web3.sha3 to web3.util.sha3 as per web3 1.0.0 change

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -17,7 +17,7 @@ const namehash = require('../node_modules/eth-ens-namehash');
 function getRootNodeFromTLD(tld) {
   return {
     namehash: namehash(tld),
-    sha3: web3.sha3(tld)
+    sha3: web3.util.sha3(tld)
   };
 }
 


### PR DESCRIPTION
web3 1.0.0 update moved web3.sha3 to web3.util.sha3, all new users that do npm install will get the most recent version of web3 
