### PR TITLE
doc: use reverse resolver instead of regular one in reverse claim

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -384,7 +384,7 @@ Alternately, you can claim and set the resolver record in one operation:
 
 ::
 
-    reverseRegistrar.claimWithResolver(eth.accounts[0], publicResolver.address, {from: eth.accounts[0]});
+    reverseRegistrar.claimWithResolver(eth.accounts[0], reverseRegistrar.defaultResolver(), {from: eth.accounts[0]});
 
 Setting up a reverse name for your address
 ------------------------------------------


### PR DESCRIPTION
Values obtained using `ensutils.js` in `geth console`, mentioned at the very start of the document in question:

``` js
> publicResolver.address
"0x5ffc014343cd971b7eb70732021e26c35b744cc4" 
> reverseRegistrar.defaultResolver()
"0x5fbb459c49bb06083c33109fa4f14810ec2cf358"
```

Etherscan code links for these:

https://etherscan.io/address/0x5ffc014343cd971b7eb70732021e26c35b744cc4#code
https://etherscan.io/address/0x5fbb459c49bb06083c33109fa4f14810ec2cf358#code